### PR TITLE
OvmfPkg: create two guid hob, gNvVariableInfoGuid and gSpiFlashInfoGuid

### DIFF
--- a/OvmfPkg/OvmfPkgPol.fdf
+++ b/OvmfPkg/OvmfPkgPol.fdf
@@ -302,10 +302,10 @@ INF  OvmfPkg/PlatformBootManagerDriver/PlatformBootManagerDriver.inf
 INF  OvmfPkg/SmmAccess/SmmAccess2Dxe.inf
 INF  OvmfPkg/SmmControl2Dxe/SmmControl2Dxe.inf
 INF  OvmfPkg/CpuS3DataDxe/CpuS3DataDxe.inf
-INF  MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
-INF  MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
+#INF  MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
+#INF  MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
 INF  OvmfPkg/CpuHotplugSmm/CpuHotplugSmm.inf
-INF  UefiCpuPkg/CpuIo2Smm/CpuIo2Smm.inf
+#INF  UefiCpuPkg/CpuIo2Smm/CpuIo2Smm.inf
 INF  MdeModulePkg/Universal/LockBox/SmmLockBox/SmmLockBox.inf
 INF  UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
 
@@ -313,9 +313,9 @@ INF  UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
 # Variable driver stack (SMM)
 #
 INF  OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesSmm.inf
-INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.inf
-INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
-INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+#INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteSmm.inf
+#INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+#INF  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
 
 !else
 

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -52,6 +52,8 @@
   gPldSerialPortInfoGuid
   gUefiAcpiBoardInfoGuid
   gPldPciRootBridgeInfoGuid
+  gSpiFlashInfoGuid
+  gNvVariableInfoGuid
 
 [LibraryClasses]
   BaseLib
@@ -73,6 +75,8 @@
   BaseMemoryLib
 
 [Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfDxeMemFvBase
@@ -116,7 +120,9 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuBootLogicalProcessorNumber
   gUefiCpuPkgTokenSpaceGuid.PcdCpuApStackSize
   gUefiCpuPkgTokenSpaceGuid.PcdSevEsIsEnabled
-
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFdBaseAddress
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareFdSize
+  gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFirmwareBlockSize
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPldFvBase
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfPldFvSize
 

--- a/OvmfPkg/PlatformPei/Upl.c
+++ b/OvmfPkg/PlatformPei/Upl.c
@@ -20,7 +20,8 @@
 #include <Library/QemuFwCfgLib.h>
 #include <OvmfPlatforms.h>
 #include <Library/BaseMemoryLib.h>
-
+#include <Guid/NvVariableInfoGuid.h>
+#include <Guid/SpiFlashInfoGuid.h>
 STATIC PLD_PCI_ROOT_BRIDGE_APERTURE mNonExistAperture = { MAX_UINT64, 0 };
 
 EFI_STATUS
@@ -363,5 +364,21 @@ UplInitialization (
   DEBUG ((DEBUG_ERROR, "%a: PciRootBridgeInfo->RootBridge[0].ResourceAssigned: 0x%04x\n",  __FUNCTION__, PciRootBridgeInfo->RootBridge[0].ResourceAssigned));
   DEBUG ((DEBUG_ERROR, "%a: PciRootBridgeInfo->RootBridge[0].ResourceAssigned: 0x%x\n",  __FUNCTION__, (UINTN)PciRootBridgeInfo->RootBridge[0].Bus.Limit));
   //PciRootBridgeInfo->RootBridge[0].ResourceAssigned = FALSE;
+
+  SPI_FLASH_INFO                   *NewSpiFlashInfo;
+  NewSpiFlashInfo = BuildGuidHob (&gSpiFlashInfoGuid, sizeof (SPI_FLASH_INFO));
+  NewSpiFlashInfo->Flags = TRUE;
+  NewSpiFlashInfo->SpiAddress.AddressSpaceId =  EFI_ACPI_3_0_PCI_CONFIGURATION_SPACE;
+  NewSpiFlashInfo->SpiAddress.RegisterBitWidth =  32;
+  NewSpiFlashInfo->SpiAddress.RegisterBitOffset =  0;
+  NewSpiFlashInfo->SpiAddress.AccessSize =  EFI_ACPI_3_0_DWORD;
+  NewSpiFlashInfo->SpiAddress.Address = (UINT64) PcdGet32 (PcdOvmfFdBaseAddress);
+
+  NV_VARIABLE_INFO                   *NewNvVariableInfo;
+  NewNvVariableInfo = BuildGuidHob (&gNvVariableInfoGuid, sizeof (NV_VARIABLE_INFO));
+  NewNvVariableInfo->VariableStoreBase = FixedPcdGet32 (PcdFlashNvStorageVariableBase64);
+  NewNvVariableInfo->VariableStoreSize= 2 * (FixedPcdGet32 (PcdFlashNvStorageVariableSize) + 0x2000);
+  // 0x2000 is a hard code value in UefiPayloadPkg\FvbRuntimeDxe\FvbInfo.c, line 95:   FtwWorkingSize = 0x2000;
+
 }
 

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -119,7 +119,9 @@ INF PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
   INF MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
   INF MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
   INF UefiCpuPkg/CpuIo2Smm/CpuIo2Smm.inf
+!if $(UNIVERSAL_PAYLOAD) == FALSE
   INF UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
+!endif
   INF UefiPayloadPkg/PchSmiDispatchSmm/PchSmiDispatchSmm.inf
 !endif
 

--- a/build_qemu_pol.bat
+++ b/build_qemu_pol.bat
@@ -32,7 +32,7 @@ if "%VS_VER%" == "" (
 )
 
 echo Building Universal UEFI payload DXE FV ...
-call build -p UefiPayloadPkg\UefiPayloadPkg.dsc -a X64 -D UNIVERSAL_PAYLOAD=TRUE -t %VS_VER% -y upllog.txt -D EMU_VARIABLE_ENABLE=TRUE
+call build -p UefiPayloadPkg\UefiPayloadPkg.dsc -a X64 -D UNIVERSAL_PAYLOAD=TRUE -t %VS_VER% -y upllog.txt
 if not %ERRORLEVEL% == 0 exit /b 1
 
 :entry
@@ -62,13 +62,13 @@ python UefiPayloadPkg\Tools\GenUpldInfo.py Build\upld_info UEFI
 
 :ovmf
 echo Building OVMF POL ...
-call build -p OvmfPkg\OvmfPkgPol.dsc -a IA32 -a X64 -D DEBUG_ON_SERIAL_PORT -t %VS_VER% -y ovmflog.txt
+call build -p OvmfPkg\OvmfPkgPol.dsc -a IA32 -a X64 -D DEBUG_ON_SERIAL_PORT  -D SMM_REQUIRE=TRUE  -t %VS_VER% -y ovmflog.txt
 @if not %ERRORLEVEL% == 0 exit /b 1
 goto :eof
 
 :run
 echo Running OVMF POL on QEMU ...
-"C:\Program Files\qemu\qemu-system-x86_64.exe" -m 512M -cpu max -machine q35,accel=tcg -bios Build\OvmfPol\DEBUG_%VS_VER%\FV\OVMF.fd -boot menu=on,splash-time=0 -net none --serial stdio
+"C:\Program Files\qemu\qemu-system-x86_64.exe" -m 512M -cpu max -machine q35,accel=tcg -drive file=Build\OvmfPol\DEBUG_%VS_VER%\FV\OVMF.fd,if=pflash,format=raw -boot menu=on,splash-time=0 -net none --serial stdio
 
 
 


### PR DESCRIPTION
Now, ovmf can boot with smm drivers
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>